### PR TITLE
Fixed Typo in tray-applet-quirks.md

### DIFF
--- a/pages/tray-applet-quirks.md
+++ b/pages/tray-applet-quirks.md
@@ -14,7 +14,7 @@ and will need additional steps.
 | ----------------------------- | ----------------------------------------------- |
 | ![](/images/distros/ubuntu.svg) Ubuntu / GNOME 3 | Install [gnome-shell-extension-appindicator](https://packages.ubuntu.com/focal/gnome-shell-extension-appindicator) using your package manager.
 | ![](/images/distros/arch.svg) Arch / GNOME 3 | Install [gnome-shell-extensions-appindicator](https://archlinux.org/packages/extra/any/gnome-shell-extension-appindicator/)
-| ![](/images/distros/gnome.svg) GNOME 3 / Other | Install a GNOME extension that provides AppIndicator support.
+| ![](/images/distros/gnome.svg) Other / GNOME 3 | Install a GNOME extension that provides AppIndicator support.
 | ![](/images/distros/elementary.svg) elementary OS / Pantheon  | Install [wingpanel-community-indicators](https://github.com/MvBonin/wingpanel-community-indicators)
 
 If things have changed, or we missed something, do let us know by raising an issue.


### PR DESCRIPTION
Changed "GNOME 3 / Other" to "Other / GNOME 3" to match headline "Distro / Environment".